### PR TITLE
Disable automatic post-install hook

### DIFF
--- a/packages/dev-config/README.md
+++ b/packages/dev-config/README.md
@@ -7,7 +7,7 @@ Stencila projects. This allows to avoid boilerplate when creating projects, have
 
 This package requires running a command to finish the installation. The command **will modify your project**:
 
-- by adding configuration properties to `package.json` (e.g. a `prettier` property that points to the Prettier configuration in this project)'
+- by adding or changing configuration properties to `package.json` (e.g. a `prettier` property that points to the Prettier configuration in this project)'
 - by adding _missing_ config files like `.editorconfig`
 
 To install run the following commands:

--- a/packages/dev-config/README.md
+++ b/packages/dev-config/README.md
@@ -5,26 +5,22 @@ Stencila projects. This allows to avoid boilerplate when creating projects, have
 
 ## Install
 
-```bash
-npm install @stencila/dev-config --save-dev
-```
-
-This package includes an installation script that **will modify your project**:
+This package requires running a command to finish the installation. The command **will modify your project**:
 
 - by adding configuration properties to `package.json` (e.g. a `prettier` property that points to the Prettier configuration in this project)'
 - by adding _missing_ config files like `.editorconfig`
 
-If you do not want that to happen run `npm install` with the `--ignore-scripts` option,
+To install run the following commands:
 
 ```bash
-npm install @stencila/dev-config --save-dev --ignore-scripts
+npm install @stencila/dev-config --save-dev
 ```
-
-If you decide you want to update your `package.json` at a later time, you can run this script manually using,
 
 ```bash
 node -e 'require("@stencila/dev-config")'
 ```
+
+If you decide you want to update your `package.json` at a later time, you can run the above command again.
 
 Note that this package includes configurations for Typescript, Jest and related tooling but does not assume that you will be using them. Configurations for these can be copied over manually e.g.
 

--- a/packages/dev-config/package.json
+++ b/packages/dev-config/package.json
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/stencila/dev-config.git"
   },
   "scripts": {
-    "postinstall": "node ./init.js"
+    "postinstall": "echo \"⚙️  @stencila/dev-config:\nIf this is the first time you’re installing this pacakge, or wish to upgrade your configuration, run: \n> node -e 'require(\"@stencila/dev-config\")'\""
   },
   "bugs": {
     "url": "https://github.com/stencila/dev-config/issues"


### PR DESCRIPTION
We've had troubles with changes in `package.json` files being silently reverted during build steps on CI due to the automatic overwriting of configurations. This makes it a manual process.