### PR TITLE
chore(CI): Add Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: node_js
+node_js: ['10']
+os: linux
+
+# Build Packages and Storybook
+script:
+  - npm ci
+  - npm run bootstrap
+
+# Prevent Github Pages from using Jekyll
+before_deploy:
+  - touch docs/.nojekyll
+
+after_success:
+  - git config --global user.email ${GIT_COMMITTER_EMAIL}
+  - git config --global user.name stencila-ci
+  - git remote set-url origin "https://${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git" > /dev/null 2>&1
+  - git checkout master
+  - git checkout .
+  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
+
+deploy:
+  # Deploy a new version of NPM packages and create a Github releases
+  - provider: script
+    skip_cleanup: true
+    on:
+      branch: master
+    script: npx lerna publish --yes

--- a/README.md
+++ b/README.md
@@ -42,16 +42,14 @@ npx lerna bootstrap
 
 ## Releasing new versions
 
-The releases are currently manually generated. Make sure you have the latest
-`master` branch of this repository, and are in the root folder when running:
+Release are generated automatically when Pull Requests are merged into the `master` branch.
 
-```bash
-git checkout master && git pull
-```
-
-To automatically increase the versions numbers for each project based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
-and release them, run:
-
-```bash
-npx lerna publish
-```
+This process is automated thanks to [conventional
+changelog](https://github.com/conventional-changelog/conventional-changelog)
+style commit messages e.g. `docs(readme): fixed spelling mistake` and
+[`semantic-release`](https://github.com/semantic-release/semantic-release).
+They enable us to automate version management: minor version releases are done if
+any `feat(...)` commits are pushed, patch version releases are done if any
+`fix(...)` commits are pushed. See [the
+specifications](https://www.conventionalcommits.org/en/v1.0.0-beta.2/) for
+full details.


### PR DESCRIPTION
This PR automates the release process for `dev-config` packages.
⚠️ Need to check that the necessary env secrets are defined in Travis