### PR TITLE
feat(Renovate): Add renovate-config

### DIFF
--- a/packages/dev-config/init.js
+++ b/packages/dev-config/init.js
@@ -43,7 +43,13 @@ const commitLint = {
   }
 }
 
-const configurations = [commitLint, esLint, husky, prettier, semanticRelease]
+const renovate = {
+  renovate: {
+    extends: ['@stencila']
+  }
+}
+
+const configurations = [commitLint, esLint, husky, prettier, renovate, semanticRelease]
 
 // Files to copy to the project (if missing)
 

--- a/packages/renovate-config/README.md
+++ b/packages/renovate-config/README.md
@@ -1,0 +1,38 @@
+# `@stencila/renovate-config`
+
+## Usage
+
+From the project where you would like to use these settings, run
+
+```bash
+npm install @stencila/renovate-config --save-dev
+```
+
+Then modify your `package.json` to include the following:
+
+```json5
+  // …
+  "renovate": {
+    "extends": ["@stencila"]
+  }
+  // …
+```
+
+The `default` preset config has a number of settings to reduce noise,
+
+- weekly updates
+- `devDependencies` are grouped into a single PR
+
+If you want to use one of the other presets (see the `renovate-config` section of this [`package.json`](package.json)) then use a semicolon and the preset name e.g.
+
+```json5
+  // …
+  "renovate": {
+    "extends": ["@stencila:groupAll"]
+  }
+  // …
+```
+
+## References
+
+- [Renovate Shared Configs](https://docs.renovatebot.com/config-presets/)

--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@stencila/renovate-config",
+  "version": "0.1.0",
+  "description": "Shared Renovate configuration for Stencila projects",
+  "keywords": [
+    "Stencila",
+    "dev",
+    "Renovate",
+    "config"
+  ],
+  "author": "Stencila <hello@stenci.la>",
+  "homepage": "https://github.com/stencila/dev-config/tree/master/packages/renovate-config#readme",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stencila/dev-config.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stencila/dev-config/issues"
+  },
+  "renovate-config": {
+    "default": {
+      "extends": ["config:base"],
+      "schedule": ["before 3am on Wednesday"],
+      "packageRules": [
+        {
+          "depTypeList": ["dependencies"]
+        },
+        {
+          "groupName": "Dev dependencies",
+          "groupSlug": "dev",
+          "depTypeList": ["devDependencies"]
+        }
+      ]
+    },
+    "groupAll": {
+      "extends": ["config:base", "group:all"],
+      "schedule": ["before 3am on Wednesday"]
+    }
+  }
+}


### PR DESCRIPTION
We are using a Renovate for most of our projects now. So this avoids duplication by establishing a shared config across those projects.

The impetus for doing this now was to reduce noise by having a Renovate config that groups `devDependencies` into a single PR but keeps `dependencies` separate.

I don't think it is possible to test this configuration without first publishing this package and then trying to use it with a "Reconfigure Renovate" PR https://docs.renovatebot.com/reconfigure-renovate/ for this repo.