### PR TITLE
Reconfigure Renovate: timezone to UTC and schedule

### DIFF
--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -26,8 +26,9 @@
       "extends": [
         "config:base"
       ],
+      "timezone": "UTC",
       "schedule": [
-        "before 3am on Wednesday"
+        "before 12pm on Wednesday"
       ],
       "packageRules": [
         {
@@ -49,8 +50,9 @@
         "config:base",
         "group:all"
       ],
+      "timezone": "UTC",
       "schedule": [
-        "before 3am on Wednesday"
+        "before 12pm on Wednesday"
       ]
     }
   }


### PR DESCRIPTION
Set timezone to UTC and schedule to the middle of the working week.

By default Renovate uses the timezone of the machine it's running on. This fixes it to UTC and changes the schedule to be the middle of the working week. Our repos can override this depending upon how far upstream they are in the repo dependency chain. See https://docs.renovatebot.com/faq/#control-renovates-schedule