### PR TITLE
fix(TSConfig): Target ESNext to fix compatability with bundlers

### DIFF
--- a/packages/dev-config/tsconfig.json
+++ b/packages/dev-config/tsconfig.json
@@ -1,13 +1,13 @@
 {
   /* See https://www.typescriptlang.org/docs/handbook/compiler-options.html */
   "compilerOptions": {
-    /* 
-      ECMAScript target version. 
+    /*
+      ECMAScript target version.
       We use the version supported by previous and lated LTS Node.
       See https://node.green
     */
     "target": "es2018",
-    "module": "commonjs",
+    "module": "ESNext",
     /* Generate type definitions */
     "declaration": true,
     /* Redirect output files to dist folder */


### PR DESCRIPTION
Close #91 

This should be a relatively safe change, but might have impact on projects which target a Node environment and don't use some transpiler such as Rollup. In those cases the setting will have to be reset to `commonjs`.