### PR TITLE
Enable auto-merging non-major dependency updates

### DIFF
--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -36,17 +36,40 @@
       "semanticCommitScope": "Dependencies",
       "packageRules": [
         {
+          "rangeStrategy": "bump",
+          "packagePatterns": [
+            "postcss"
+          ],
+          "updateTypes": [
+            "major"
+          ]
+        },
+        {
           "depTypeList": [
             "dependencies"
           ],
-          "rangeStrategy": "bump"
+          "rangeStrategy": "bump",
+          "updateTypes": [
+            "minor",
+            "patch",
+            "pin",
+            "digest"
+          ],
+          "automerge": true
         },
         {
           "groupName": "Dev dependencies",
           "groupSlug": "dev",
           "depTypeList": [
             "devDependencies"
-          ]
+          ],
+          "updateTypes": [
+            "minor",
+            "patch",
+            "pin",
+            "digest"
+          ],
+          "automerge": true
         }
       ]
     },


### PR DESCRIPTION
This PR:
- Enables [Renovate's PR auto-merging](https://docs.renovatebot.com/configuration-options/#automerge)
  -  Something to evaluate for the future is the [`automergeType: branch`](https://docs.renovatebot.com/configuration-options/#automergetype) which will reduce the notification levels in GitHub at the expense of lower visibility of the changes occurring with the project dependencies.
- Skips major updates for PostCSS dependencies until the v8 ecosystem has stabilized